### PR TITLE
Added initial support for CHRS kludge

### DIFF
--- a/lib/msgapi/message.go
+++ b/lib/msgapi/message.go
@@ -38,9 +38,11 @@ func (m *Message) ParseRaw() error {
     } else if len(l)>10 && l[0:11]=="\x20*\x20Origin: " {
       re := regexp.MustCompile("\\d+:\\d+/\\d+\\.*\\d*")
       m.kludges["ORIGIN"]=re.FindStringSubmatch(l)[0];
+    } else if len(l)>6 && l[0:7]=="\x01CHRS: " {
+      m.kludges["CHRS"]=strings.Split(l," ")[1]
     }
   }
-  log.Printf("%#v", m.kludges)
+  log.Printf("ParseRaw(): %#v", m.kludges)
   if m.FromAddr==nil {
     if _, ok := m.kludges["INTL"]; ok {
       m.ToAddr=types.AddrFromString(strings.Split(m.kludges["INTL"]," ")[0])
@@ -61,7 +63,11 @@ func (m *Message) ParseRaw() error {
 }
 
 func (m *Message) Decode() {
-  enc:="CP866"
+  enc := "CP866"
+  if _, ok := m.kludges["CHRS"]; ok {
+    enc = m.kludges["CHRS"]
+  }
+  log.Printf("Decode(): %#v", m.kludges)
   m.Body=utils.DecodeCharmap(m.Body,enc)
   m.From=utils.DecodeCharmap(m.From,enc)
   m.To=utils.DecodeCharmap(m.To,enc)

--- a/lib/utils/encoding.go
+++ b/lib/utils/encoding.go
@@ -12,11 +12,16 @@ func DecodeCharmap(s string, c string) string {
   var tr *transform.Reader
   if c=="CP866" {
     tr=transform.NewReader(sr, charmap.CodePage866.NewDecoder())
+  } else if c=="CP850" {
+    tr=transform.NewReader(sr, charmap.CodePage850.NewDecoder())
+  } else if c=="CP437" {
+    tr=transform.NewReader(sr, charmap.CodePage437.NewDecoder())
+  } else {
+    tr=transform.NewReader(sr, charmap.ISO8859_1.NewDecoder())
   }
   b, err := ioutil.ReadAll(tr)
   if err!=nil {
     panic(err)
   }
   return string(b)
-  
 }


### PR DESCRIPTION
Supported encodings: CP866, CP437, CP850
Others are treated as ISO8859-1 aka LATIN-1
If CHRS not defined - fallback to CP866